### PR TITLE
Ignore built files (*.pce, *.s, *.sym)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# built files
+*.pce
+*.s
+*.sym


### PR DESCRIPTION
It's not good to commit built files to the repository, and a .gitignore file will make sure you can't do that!
